### PR TITLE
Add SystemLanguageModel context size and token count

### DIFF
--- a/foundation-models-c/Sources/FoundationModelsCBindings/FoundationModelsCBindings.swift
+++ b/foundation-models-c/Sources/FoundationModelsCBindings/FoundationModelsCBindings.swift
@@ -170,6 +170,168 @@ public func FMSystemLanguageModelIsAvailable(
   }
 }
 
+// MARK: - Token counting and context size
+
+/// Error thrown when a token-counting API is invoked on an OS older than the version that
+/// introduced it (26.4).
+private func tokenCountUnsupportedOSError() -> Error {
+  NSError(
+    domain: "TokenCount",
+    code: -1,
+    userInfo: [
+      NSLocalizedDescriptionKey: "Token counting requires macOS 26.4, iOS 26.4, or visionOS 26.4 or later."
+    ]
+  )
+}
+
+/// Returns the model's maximum context window size, measured in tokens.
+@_cdecl("FMSystemLanguageModelGetContextSize")
+public func FMSystemLanguageModelGetContextSize(model: FMSystemLanguageModelRef) -> Int32 {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+  return Int32(model.contextSize)
+}
+
+/// Shared async machinery for the `tokenCount` family of bindings.
+///
+/// Runs `work`, which produces the token count for some input, and forwards either the
+/// resulting count or a mapped error to `callback`.
+private func performTokenCount(
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback,
+  work: @escaping @Sendable () async throws -> Int
+) -> FMTaskRef {
+  let unsafeSendableUserInfo = UnsafeSendableUserInfo(pointer: userInfo)
+  let task = Task.detached {
+    do {
+      try Task.checkCancellation()
+      let count = try await work()
+      try Task.checkCancellation()
+      callback(StatusCode.success.rawValue, Int32(count), nil, unsafeSendableUserInfo.pointer)
+    } catch is CancellationError {
+      let message = "Operation cancelled"
+      message.withCString { cString in
+        callback(StatusCode.unknownError.rawValue, 0, cString, unsafeSendableUserInfo.pointer)
+      }
+    } catch let error as LanguageModelSession.GenerationError {
+      let statusCode = mapGenerationErrorToStatusCode(error)
+      error.localizedDescription.withCString { cString in
+        callback(statusCode, 0, cString, unsafeSendableUserInfo.pointer)
+      }
+    } catch {
+      let debugDescription = formatErrorDescription(error)
+      debugDescription.withCString { cString in
+        callback(StatusCode.unknownError.rawValue, 0, cString, unsafeSendableUserInfo.pointer)
+      }
+    }
+  }
+  let taskBox = TaskBox(task)
+  return FMTaskRef(Unmanaged.passRetained(taskBox).toOpaque())
+}
+
+/// Counts the tokens in a composed prompt.
+@_cdecl("FMSystemLanguageModelTokenCountForPrompt")
+public func FMSystemLanguageModelTokenCountForPrompt(
+  model: FMSystemLanguageModelRef,
+  composedPrompt: FMComposedPrompt,
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback
+) -> FMTaskRef {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+  let prompt = Unmanaged<ComposedPrompt>.fromOpaque(composedPrompt).takeUnretainedValue()
+    .promptRepresentation
+  return performTokenCount(userInfo: userInfo, callback: callback) {
+    guard #available(macOS 26.4, iOS 26.4, visionOS 26.4, *) else {
+      throw tokenCountUnsupportedOSError()
+    }
+    return try await model.tokenCount(for: prompt)
+  }
+}
+
+/// Counts the tokens in instructions composed from the given text.
+@_cdecl("FMSystemLanguageModelTokenCountForInstructions")
+public func FMSystemLanguageModelTokenCountForInstructions(
+  model: FMSystemLanguageModelRef,
+  instructions: UnsafePointer<CChar>,
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback
+) -> FMTaskRef {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+  let instructions = Instructions(String(cString: instructions))
+  return performTokenCount(userInfo: userInfo, callback: callback) {
+    guard #available(macOS 26.4, iOS 26.4, visionOS 26.4, *) else {
+      throw tokenCountUnsupportedOSError()
+    }
+    return try await model.tokenCount(for: instructions)
+  }
+}
+
+/// Counts the tokens contributed by the given tools.
+@_cdecl("FMSystemLanguageModelTokenCountForTools")
+public func FMSystemLanguageModelTokenCountForTools(
+  model: FMSystemLanguageModelRef,
+  tools: UnsafeMutablePointer<FMBridgedToolRef>?,
+  toolCount: Int32,
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback
+) -> FMTaskRef {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+
+  var collectedTools: [any Tool] = []
+  if let tools = tools, toolCount > 0 {
+    for i in 0..<Int(toolCount) {
+      let bridgedTool = Unmanaged<BridgedTool>.fromOpaque(tools[i]).takeUnretainedValue()
+      collectedTools.append(bridgedTool)
+    }
+  }
+  let toolArray = collectedTools
+
+  return performTokenCount(userInfo: userInfo, callback: callback) {
+    guard #available(macOS 26.4, iOS 26.4, visionOS 26.4, *) else {
+      throw tokenCountUnsupportedOSError()
+    }
+    return try await model.tokenCount(for: toolArray)
+  }
+}
+
+/// Counts the tokens in a generation schema.
+@_cdecl("FMSystemLanguageModelTokenCountForSchema")
+public func FMSystemLanguageModelTokenCountForSchema(
+  model: FMSystemLanguageModelRef,
+  schema: FMGenerationSchemaRef,
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback
+) -> FMTaskRef {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+  let schemaBuilder = Unmanaged<GenerationSchemaBuilder>.fromOpaque(schema).takeUnretainedValue()
+  return performTokenCount(userInfo: userInfo, callback: callback) {
+    guard #available(macOS 26.4, iOS 26.4, visionOS 26.4, *) else {
+      throw tokenCountUnsupportedOSError()
+    }
+    let schema = try schemaBuilder.buildSchema()
+    return try await model.tokenCount(for: schema)
+  }
+}
+
+/// Counts the tokens in the transcript held by the given session.
+@_cdecl("FMSystemLanguageModelTokenCountForTranscript")
+public func FMSystemLanguageModelTokenCountForTranscript(
+  model: FMSystemLanguageModelRef,
+  transcriptSession: FMLanguageModelSessionRef,
+  userInfo: UnsafeMutableRawPointer?,
+  callback: FMSystemLanguageModelTokenCountCallback
+) -> FMTaskRef {
+  let model = Unmanaged<SystemLanguageModel>.fromOpaque(model).takeUnretainedValue()
+  let session = Unmanaged<LanguageModelSession>.fromOpaque(transcriptSession)
+    .takeUnretainedValue()
+  let transcript = session.transcript
+  return performTokenCount(userInfo: userInfo, callback: callback) {
+    guard #available(macOS 26.4, iOS 26.4, visionOS 26.4, *) else {
+      throw tokenCountUnsupportedOSError()
+    }
+    return try await model.tokenCount(for: transcript)
+  }
+}
+
 // MARK: - Session creation from SystemLanguageModel
 
 @_cdecl("FMLanguageModelSessionCreateDefault")

--- a/foundation-models-c/Sources/FoundationModelsCBindings/include/FoundationModels.h
+++ b/foundation-models-c/Sources/FoundationModelsCBindings/include/FoundationModels.h
@@ -22,6 +22,7 @@ typedef const void *FMBridgedToolRef;
 // Callbacks
 typedef void (*_Nonnull FMLanguageModelSessionResponseCallback)(int status, const char *_Nullable content, size_t length, void *_Nullable userInfo) __attribute__((swift_attr("@Sendable")));
 typedef void (*_Nonnull FMLanguageModelSessionStructuredResponseCallback)(int status, FMGeneratedContentRef _Nullable content, void *_Nullable userInfo) __attribute__((swift_attr("@Sendable")));
+typedef void (*_Nonnull FMSystemLanguageModelTokenCountCallback)(int status, int tokenCount, const char *_Nullable errorDescription, void *_Nullable userInfo) __attribute__((swift_attr("@Sendable")));
 
 // MARK: - SystemLanguageModel
 
@@ -51,6 +52,10 @@ typedef enum
 FMSystemLanguageModelRef _Nonnull FMSystemLanguageModelGetDefault();
 FMSystemLanguageModelRef _Nonnull FMSystemLanguageModelCreate(FMSystemLanguageModelUseCase useCase, FMSystemLanguageModelGuardrails guardrails);
 bool FMSystemLanguageModelIsAvailable(FMSystemLanguageModelRef _Nonnull ref, FMSystemLanguageModelUnavailableReason *_Nullable unavailableReason);
+
+// Returns the model's maximum context window size, measured in tokens.
+int FMSystemLanguageModelGetContextSize(FMSystemLanguageModelRef _Nonnull model);
+
 FMLanguageModelSessionRef _Nonnull FMLanguageModelSessionCreateDefault();
 FMLanguageModelSessionRef _Nonnull FMLanguageModelSessionCreateFromSystemLanguageModel(FMSystemLanguageModelRef _Nullable model, const char *_Nullable instructions, FMBridgedToolRef _Nullable *_Nullable tools, int toolCount);
 
@@ -73,6 +78,17 @@ void FMComposedPromptAddText(FMComposedPrompt _Nonnull composedPrompt, const cha
 bool FMComposedPromptAddImage(FMComposedPrompt _Nonnull composedPrompt, const char *_Nonnull imagePath, FMComposedPromptAddImageError * _Nullable error);
 bool FMComposedPromptAddIdentifiedImage(FMComposedPrompt _Nonnull composedPrompt, const char *_Nonnull imagePath, const char *_Nonnull imageIdentifier, FMComposedPromptAddImageError * _Nullable error);
 bool FMComposedPromptAddAttachment(FMComposedPrompt _Nonnull composedPrompt, const char *_Nonnull imagePath, const char *_Nullable label, FMComposedPromptAddImageError * _Nullable error);
+
+// MARK: - Token counting
+
+// Token counting. Each function dispatches asynchronously and reports the count (or an error)
+// via the callback. The returned FMTaskRef can be cancelled with FMTaskCancel and must be
+// released with FMRelease.
+FMTaskRef FMSystemLanguageModelTokenCountForPrompt(FMSystemLanguageModelRef _Nonnull model, FMComposedPrompt _Nonnull composedPrompt, void *_Nullable userInfo, FMSystemLanguageModelTokenCountCallback callback);
+FMTaskRef FMSystemLanguageModelTokenCountForInstructions(FMSystemLanguageModelRef _Nonnull model, const char *_Nonnull instructions, void *_Nullable userInfo, FMSystemLanguageModelTokenCountCallback callback);
+FMTaskRef FMSystemLanguageModelTokenCountForTools(FMSystemLanguageModelRef _Nonnull model, FMBridgedToolRef _Nullable *_Nullable tools, int toolCount, void *_Nullable userInfo, FMSystemLanguageModelTokenCountCallback callback);
+FMTaskRef FMSystemLanguageModelTokenCountForSchema(FMSystemLanguageModelRef _Nonnull model, FMGenerationSchemaRef _Nonnull schema, void *_Nullable userInfo, FMSystemLanguageModelTokenCountCallback callback);
+FMTaskRef FMSystemLanguageModelTokenCountForTranscript(FMSystemLanguageModelRef _Nonnull model, FMLanguageModelSessionRef _Nonnull transcriptSession, void *_Nullable userInfo, FMSystemLanguageModelTokenCountCallback callback);
 
 // Response functions
 

--- a/foundation-models-c/Tests/FoundationModelsCBindingsTests/BasicSystemModelTests.swift
+++ b/foundation-models-c/Tests/FoundationModelsCBindingsTests/BasicSystemModelTests.swift
@@ -44,9 +44,12 @@ import Synchronization
       0
     )
     var isResponding: Bool = true
-    FMLanguageModelSessionRespond(
+    let prompt = FMComposedPromptInitialize()
+    FMComposedPromptAddText(prompt, "What programming language is better, Swift or C?")
+    let task = FMLanguageModelSessionRespond(
       session,
-      "What programming language is better, Swift or C?",
+      prompt,
+      nil,
       &isResponding
     ) { status, content, length, userInfo in
       #expect(status == 0)
@@ -57,6 +60,8 @@ import Synchronization
       userInfo?.bindMemory(to: Bool.self, capacity: 1).pointee = false
     }
     while isResponding {}
+    FMRelease(task)
+    FMRelease(prompt)
     FMRelease(session)
     FMRelease(model)
   }
@@ -206,5 +211,43 @@ import Synchronization
     let uniqueCount = idTracker.withLock { $0.count }
     #expect(uniqueCount == numberOfCalls)
     print("Generated \(uniqueCount) unique IDs out of \(numberOfCalls) calls")
+  }
+
+  @Test func testContextSize() async throws {
+    let model = FMSystemLanguageModelGetDefault()
+    let contextSize = FMSystemLanguageModelGetContextSize(model)
+    #expect(contextSize >= 0)
+    FMRelease(model)
+  }
+
+  @Test(.enabled(if: SystemLanguageModel.default.isAvailable))
+  func testTokenCountForPrompt() async throws {
+    let model = FMSystemLanguageModelGetDefault()
+    let prompt = FMComposedPromptInitialize()
+    FMComposedPromptAddText(prompt, "Hello, how are you?")
+
+    final class TokenCountResult: @unchecked Sendable {
+      let mutex = Mutex<(done: Bool, status: Int, count: Int)>((false, -1, -1))
+    }
+    let result = TokenCountResult()
+
+    let task = FMSystemLanguageModelTokenCountForPrompt(
+      model,
+      prompt,
+      Unmanaged.passUnretained(result).toOpaque()
+    ) { status, count, _, userInfo in
+      let result = Unmanaged<TokenCountResult>.fromOpaque(userInfo!).takeUnretainedValue()
+      result.mutex.withLock { $0 = (true, Int(status), Int(count)) }
+    }
+
+    while result.mutex.withLock({ !$0.done }) {}
+
+    let (_, status, count) = result.mutex.withLock { $0 }
+    #expect(status == 0)
+    #expect(count > 0, "Prompt should produce a positive token count")
+
+    FMRelease(task)
+    FMRelease(prompt)
+    FMRelease(model)
   }
 }

--- a/src/apple_fm_sdk/c_helpers.py
+++ b/src/apple_fm_sdk/c_helpers.py
@@ -425,6 +425,57 @@ def _session_structured_callback(status, content_ptr, future_handle):
             )
 
 
+@lib.FMSystemLanguageModelTokenCountCallback
+def _token_count_callback(status, token_count, error_desc, future_handle):
+    """ctypes callback for token counting.
+
+    Resolves the registered future with the integer token count on success, or with
+    an appropriate exception (built from the status code and optional error description)
+    on failure.
+    """
+
+    async def _set_future_result(future: asyncio.Future, result):
+        if not future.cancelled():
+            future.set_result(result)
+
+    async def _set_future_exception(future: asyncio.Future, e):
+        if not future.cancelled():
+            future.set_exception(e)
+
+    try:
+        future = _safe_from_handle(future_handle)
+        if future is None or future.cancelled():
+            return
+
+        if status == GenerationErrorCode.SUCCESS:
+            asyncio.run_coroutine_threadsafe(
+                _set_future_result(future, int(token_count)), future.get_loop()
+            )
+        else:
+            debug_description = None
+            if error_desc:
+                try:
+                    debug_description = ctypes.string_at(error_desc).decode("utf-8")
+                except Exception:
+                    debug_description = None
+            error = _status_code_to_exception(
+                status, debug_description=debug_description
+            )
+            asyncio.run_coroutine_threadsafe(
+                _set_future_exception(future, error), future.get_loop()
+            )
+
+    except Exception as e:
+        try:
+            future = _safe_from_handle(future_handle)
+            if future and not future.cancelled():
+                asyncio.run_coroutine_threadsafe(
+                    _set_future_exception(future, e), future.get_loop()
+                )
+        except Exception as error:
+            logger.error(f"Unhandled Exception in token count callback cleanup: {error}")
+
+
 class StreamingCallback:
     """
     Callback handler for streaming generation responses.

--- a/src/apple_fm_sdk/core.py
+++ b/src/apple_fm_sdk/core.py
@@ -26,13 +26,23 @@ Example:
 
 from .c_helpers import (
     _ManagedObject,
+    _register_handle,
+    _token_count_callback,
+    _unregister_handle,
 )
 from enum import IntEnum
-from typing import Optional
+from typing import Optional, TYPE_CHECKING, Union
 from .errors import FoundationModelsError
 
+import asyncio
 import ctypes
 from ctypes import c_int
+
+if TYPE_CHECKING:
+    from .prompt import Prompt
+    from .generation_schema import GenerationSchema
+    from .transcript import Transcript
+    from .tool import Tool
 
 try:
     from . import _ctypes_bindings as lib
@@ -229,3 +239,161 @@ class SystemLanguageModel(_ManagedObject):
             return True, None
         else:
             return False, SystemLanguageModelUnavailableReason(reason.value)
+
+    @property
+    def context_size(self) -> int:
+        """The model's maximum context window size, measured in tokens.
+
+        The context size is the total number of tokens (prompt, instructions, tools,
+        and response combined) that the model can process in a single session. Use
+        :meth:`token_count` to measure how many tokens a given input consumes and
+        compare it against this value.
+
+        :return: The maximum context window size in tokens.
+        :rtype: int
+
+        Example:
+            Checking how much of the context window a prompt uses::
+
+                import apple_fm_sdk as fm
+
+                model = fm.SystemLanguageModel()
+                budget = model.context_size
+                used = await model.token_count("Tell me about the history of Swift.")
+                print(f"Using {used} of {budget} tokens")
+        """
+        return int(lib.FMSystemLanguageModelGetContextSize(self._ptr))
+
+    async def _token_count(self, start_task) -> int:
+        """Run a token-counting C call and await its result.
+
+        :param start_task: A callable that takes ``(future_handle, callback)`` and
+            returns the native ``FMTaskRef`` for the dispatched work.
+        :type start_task: Callable
+        :return: The token count returned by the model.
+        :rtype: int
+        """
+        loop = asyncio.get_running_loop()
+        future = loop.create_future()
+        future_handle = _register_handle(future)
+
+        task = start_task(future_handle, _token_count_callback)
+        try:
+            await future
+        except asyncio.CancelledError:
+            lib.FMTaskCancel(task)
+            future.cancel()
+            raise
+        finally:
+            _unregister_handle(future_handle)
+            lib.FMRelease(task)
+
+        return future.result()
+
+    async def token_count(
+        self,
+        value: "Optional[Union[Prompt, GenerationSchema, Transcript, list[Tool]]]" = None,
+        *,
+        instructions: Optional[str] = None,
+    ) -> int:
+        """Count the number of tokens a given input would consume.
+
+        This method measures how many tokens the model would use to represent the
+        provided input, without running generation. It supports several input kinds:
+
+        1. **Prompt** (a string or list of prompt components): pass the prompt as ``value``
+        2. **Instructions** (system instructions text): pass via the ``instructions`` keyword
+        3. **Tools** (a list of :class:`~apple_fm_sdk.tool.Tool`): pass the list as ``value``
+        4. **GenerationSchema**: pass the schema as ``value``
+        5. **Transcript**: pass the transcript as ``value``
+
+        Compare the result against :attr:`context_size` to gauge how much of the
+        model's context window an input occupies.
+
+        :param value: The input to count tokens for. One of a prompt (``str`` or list
+            of prompt components), a list of :class:`~apple_fm_sdk.tool.Tool`, a
+            :class:`~apple_fm_sdk.generation_schema.GenerationSchema`, or a
+            :class:`~apple_fm_sdk.transcript.Transcript`. Omit when counting tokens
+            for ``instructions``.
+        :type value: Union[Prompt, GenerationSchema, Transcript, list[Tool]]
+        :param instructions: System instructions text to count tokens for. Mutually
+            exclusive with ``value``.
+        :type instructions: Optional[str]
+        :return: The number of tokens the input consumes.
+        :rtype: int
+        :raises ValueError: If both ``value`` and ``instructions`` are provided, or
+            if neither is provided.
+        :raises FoundationModelsError: If token counting fails.
+
+        Examples:
+            Counting tokens in a prompt::
+
+                import apple_fm_sdk as fm
+
+                model = fm.SystemLanguageModel()
+                count = await model.token_count("Hello, world!")
+
+            Counting tokens in instructions::
+
+                count = await model.token_count(instructions="You are a helpful assistant.")
+
+            Counting tokens for tools, a schema, or a transcript::
+
+                count = await model.token_count([CalculatorTool(), WeatherTool()])
+                count = await model.token_count(Cat.generation_schema())
+                count = await model.token_count(session.transcript)
+        """
+        # Imported lazily to avoid circular imports at module load time.
+        from .generation_schema import GenerationSchema
+        from .transcript import Transcript
+        from .tool import Tool
+        from .prompt import _composed_prompt_from_prompt
+
+        if instructions is not None:
+            if value is not None:
+                raise ValueError(
+                    "Provide either a value or instructions to token_count(), not both"
+                )
+            instructions_cstr = instructions.encode("utf-8")
+            return await self._token_count(
+                lambda handle, cb: lib.FMSystemLanguageModelTokenCountForInstructions(
+                    self._ptr, instructions_cstr, handle, cb
+                )
+            )
+
+        if value is None:
+            raise ValueError("token_count() requires either a value or instructions")
+
+        if isinstance(value, GenerationSchema):
+            return await self._token_count(
+                lambda handle, cb: lib.FMSystemLanguageModelTokenCountForSchema(
+                    self._ptr, value._ptr, handle, cb
+                )
+            )
+
+        if isinstance(value, Transcript):
+            return await self._token_count(
+                lambda handle, cb: lib.FMSystemLanguageModelTokenCountForTranscript(
+                    self._ptr, value.session_ptr, handle, cb
+                )
+            )
+
+        # A list of Tool instances.
+        if isinstance(value, list) and all(isinstance(t, Tool) for t in value):
+            tool_count = len(value)
+            tool_refs = (ctypes.c_void_p * tool_count)()
+            for i, tool in enumerate(value):
+                tool_refs[i] = tool._ptr
+            return await self._token_count(
+                lambda handle, cb: lib.FMSystemLanguageModelTokenCountForTools(
+                    self._ptr, tool_refs, tool_count, handle, cb
+                )
+            )
+
+        # Otherwise treat the value as a prompt (str or list of prompt components).
+        composed_prompt = _composed_prompt_from_prompt(value)
+        return await self._token_count(
+            lambda handle, cb: lib.FMSystemLanguageModelTokenCountForPrompt(
+                self._ptr, composed_prompt, handle, cb
+            )
+        )

--- a/src/apple_fm_sdk/prompt.py
+++ b/src/apple_fm_sdk/prompt.py
@@ -285,3 +285,35 @@ class ImagePromptError(PromptError):
     """
 
     pass
+
+
+def _composed_prompt_from_prompt(prompt: "Prompt"):
+    """Build an ``FMComposedPrompt`` (the native prompt type) from a :data:`Prompt`.
+
+    Accepts a single text string, a single :class:`Attachment`, or a list mixing the
+    two, and appends each component to a freshly initialized composed prompt.
+
+    :param prompt: The prompt to convert.
+    :return: A native ``FMComposedPrompt`` pointer.
+    :raises PromptError: If a component is not a ``str`` or :class:`Attachment`.
+    """
+    composed_prompt = lib.FMComposedPromptInitialize()
+
+    def add_component(component):
+        if isinstance(component, str):
+            lib.FMComposedPromptAddText(composed_prompt, component.encode("utf-8"))
+        elif isinstance(component, Attachment):
+            component.add_to_composed_prompt(composed_prompt=composed_prompt)
+        else:
+            raise PromptError(
+                f"Unsupported prompt component type {type(component)}, only str, Image, IdentifiedImage, and Attachment are supported"
+            )
+
+    from collections.abc import Iterable
+
+    if isinstance(prompt, Iterable) and not isinstance(prompt, str):
+        for element in prompt:
+            add_component(element)
+    else:
+        add_component(prompt)
+    return composed_prompt

--- a/src/apple_fm_sdk/session.py
+++ b/src/apple_fm_sdk/session.py
@@ -5,7 +5,7 @@ import asyncio
 import json
 import logging
 from apple_fm_sdk.transcript import Transcript
-from apple_fm_sdk.prompt import Prompt, Attachment, PromptError
+from apple_fm_sdk.prompt import Prompt, _composed_prompt_from_prompt
 from .c_helpers import (
     _ManagedObject,
     _register_handle,
@@ -22,7 +22,6 @@ from .generation_options import GenerationOptions
 import threading
 import queue
 from typing import Any, Optional, AsyncIterator, Type, overload, Union
-from collections.abc import Iterable
 from .errors import FoundationModelsError
 
 import ctypes
@@ -273,24 +272,7 @@ class LanguageModelSession(_ManagedObject):
         """
         Creates a FMComposedPrompt (i.e. the C type that represents a prompt) based on a Prompt.
         """
-        composed_prompt = lib.FMComposedPromptInitialize()
-
-        def add_component_to_composed_prompt(component):
-            if isinstance(component, str):
-                lib.FMComposedPromptAddText(composed_prompt, component.encode("utf-8"))
-            elif isinstance(component, Attachment):
-                component.add_to_composed_prompt(composed_prompt=composed_prompt)
-            else:
-                raise PromptError(
-                    f"Unsupported prompt component type {type(component)}, only str, Image, IdentifiedImage, and Attachment are supported"
-                )
-
-        if isinstance(prompt, Iterable) and not isinstance(prompt, str):
-            for element in prompt:
-                add_component_to_composed_prompt(element)
-        else:
-            add_component_to_composed_prompt(prompt)
-        return composed_prompt
+        return _composed_prompt_from_prompt(prompt)
 
     @property
     def is_responding(self) -> bool:

--- a/tests/test_token_count.py
+++ b/tests/test_token_count.py
@@ -1,0 +1,138 @@
+# For licensing see accompanying LICENSE file.
+# Copyright (C) 2026 Apple Inc. All Rights Reserved.
+
+"""
+Tests for SystemLanguageModel token counting and context size.
+"""
+
+import apple_fm_sdk as fm
+import pytest
+
+from tester_tools.tester_tools import SimpleCalculatorTool, GetUserInfoTool
+import tester_schemas.schemas as tester_schemas
+
+
+# MARK: - Context size
+
+
+def test_context_size(model):
+    """The model exposes a positive context window size."""
+    context_size = model.context_size
+    assert isinstance(context_size, int)
+    assert context_size >= 1, "Context size should be positive"
+
+
+# MARK: - Basic prompt token counting
+
+
+@pytest.mark.asyncio
+async def test_token_count_simple_prompt(model):
+    """A short prompt produces a small, positive token count."""
+    short = await model.token_count("Hello")
+    longer = await model.token_count(
+        "Hello, this is a considerably longer prompt with many more words in it."
+    )
+    assert short > 0
+    assert longer > short, "A longer prompt should count more tokens"
+
+
+@pytest.mark.asyncio
+async def test_token_count_increases_with_length(model):
+    """Longer prompts yield more tokens than shorter ones."""
+    short = await model.token_count("Hi")
+    long = await model.token_count(
+        "This is a much longer prompt with many more words that should result "
+        "in a higher token count"
+    )
+    assert long > short
+
+
+@pytest.mark.asyncio
+async def test_token_count_is_deterministic(model):
+    """The same prompt always produces the same token count."""
+    prompt = "This is a test prompt"
+    first = await model.token_count(prompt)
+    second = await model.token_count(prompt)
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_token_count_list_prompt(model):
+    """A prompt expressed as a list of text components is supported."""
+    count = await model.token_count(["First line of text", "Second line of text"])
+    assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_token_count_unicode(model):
+    """Non-English text and emoji produce tokens."""
+    assert await model.token_count("こんにちは世界") > 0
+    assert await model.token_count("Hello 👋 world 🌍") > 0
+
+
+# MARK: - Instructions
+
+
+@pytest.mark.asyncio
+async def test_token_count_instructions(model):
+    """Instructions text produces a positive token count."""
+    count = await model.token_count(instructions="You are a helpful assistant")
+    assert count > 0
+
+
+# MARK: - Tools
+
+
+@pytest.mark.asyncio
+async def test_token_count_single_tool(model):
+    """A single tool contributes tokens."""
+    count = await model.token_count([SimpleCalculatorTool()])
+    assert count > 0
+
+
+@pytest.mark.asyncio
+async def test_token_count_more_tools_more_tokens(model):
+    """More tools increase the token count."""
+    single = await model.token_count([SimpleCalculatorTool()])
+    multiple = await model.token_count([SimpleCalculatorTool(), GetUserInfoTool()])
+    assert multiple > single
+
+
+# MARK: - Schema
+
+
+@pytest.mark.asyncio
+async def test_token_count_schema(model):
+    """A generation schema produces a positive token count."""
+    count = await model.token_count(tester_schemas.Cat.generation_schema())
+    print(count)
+    assert count > 0
+
+
+# MARK: - Transcript
+
+
+@pytest.mark.asyncio
+async def test_token_count_transcript(model):
+    """A populated session transcript produces a positive token count."""
+    session = fm.LanguageModelSession(model=model)
+    await session.respond("Say hello briefly.")
+    count = await model.token_count(session.transcript)
+    assert count > 0
+
+
+# MARK: - Argument validation
+
+
+@pytest.mark.asyncio
+async def test_token_count_requires_an_argument(model):
+    """Calling without a value or instructions raises ValueError."""
+    with pytest.raises(ValueError):
+        await model.token_count()
+
+
+@pytest.mark.asyncio
+async def test_token_count_rejects_value_and_instructions(model):
+    """Passing both a value and instructions raises ValueError."""
+    with pytest.raises(ValueError):
+        await model.token_count("Hello", instructions="You are an assistant")


### PR DESCRIPTION
This PR adds the below API in Python SDK:
- `SystemLanguageModel.context_size`, the model's maximum context window size in tokens.
-  `SystemLanguageModel.token_count(...)`, which counts tokens for a prompt, instructions, a list of tools, a generation schema, or a session transcript. 